### PR TITLE
Update NTFSSecurity.format.ps1xml

### DIFF
--- a/NTFSSecurity/NTFSSecurity.format.ps1xml
+++ b/NTFSSecurity/NTFSSecurity.format.ps1xml
@@ -146,8 +146,7 @@
               </TableColumnItem>
               <TableColumnItem>
                 <ScriptBlock>
-                  [Security2.FileSystemSecurity2]::ConvertTo
-                  ($_.InheritanceFlags, $_.PropagationFlags)
+                  [Security2.FileSystemSecurity2]::ConvertToApplyTo($_.InheritanceFlags, $_.PropagationFlags)
                 </ScriptBlock>
               </TableColumnItem>
               <TableColumnItem>


### PR DESCRIPTION
On line 149, "ApplyTo" seems to have been replaced by a carriage return.

fixes #56 